### PR TITLE
Plugged in the env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+API_URL=https://localhost
+API_KEY=string

--- a/src/app/types/global.d.ts
+++ b/src/app/types/global.d.ts
@@ -1,0 +1,5 @@
+declare module '*.scss'
+declare module '*.png'
+declare module '*.jpeg'
+declare module '*.jpg'
+declare module '*.svg'

--- a/src/app/types/vite-environment.d.ts
+++ b/src/app/types/vite-environment.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+type ImportMetaEnvironment = {
+  readonly API_URL: string
+  readonly API_KEY: string
+}
+
+type ImportMeta = {
+  readonly env: ImportMetaEnvironment
+}

--- a/src/vite-environment.d.ts
+++ b/src/vite-environment.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
   base: './',
-
   build: {
     sourcemap: true,
     minify: false,
@@ -16,4 +15,5 @@ export default defineConfig({
       scopeBehaviour: 'local',
     },
   },
+  envPrefix: ['API_'],
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   test: {
     globals: true,
   },
+  envPrefix: ['API_'],
 })


### PR DESCRIPTION
Добавил env файлы для обращения к бэку по url/ключу. Если переменные или их типы окажутся чуть другими - поменяем, а пока так

Вот пример использования в коде (ts, tsx). Такая запись заработает и в тестах:

```ts
  const apiUrl: string = import.meta.env.API_URL
  const apiKey: string = import.meta.env.API_KEY
  console.log(apiUrl)
  console.log(apiKey)

```