### PR TITLE
Vite's server.fs.deny bypassed with /. for files under project root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "stylelint-config-standard-scss": "^14.0.0",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.26.1",
-        "vite": "^6.3.1",
+        "vite": "^6.3.5",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.1.2"
       }
@@ -8113,18 +8113,18 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.2.tgz",
-      "integrity": "sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.4.3",
+        "fdir": "^6.4.4",
         "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
         "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.12"
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "stylelint-config-standard-scss": "^14.0.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",
-    "vite": "^6.3.1",
+    "vite": "^6.3.5",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.1.2"
   },


### PR DESCRIPTION
1. Issue title: Vite's server.fs.deny bypassed with /. for files under project root
2. [Issue link](https://github.com/sorcerers-apprentices/eCommerce-Application/security/dependabot/1)
3. Done 09.05.2025
4. Notes: В PR нет нового функционала, единственное изменение - обновление Vite, чтоб закрыть уведомление от [dependabot](https://docs.github.com/code-security/dependabot/dependabot-alerts): https://github.com/sorcerers-apprentices/eCommerce-Application/security/dependabot/1
